### PR TITLE
update_iss32_docs_n

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OpenStreetMapX"
 uuid = "86cd37e6-c0ff-550b-95fe-21d72c8d4fc9"
 authors = ["Przemyslaw Szufel <pszufe@gmail.com>", "Bartosz Pankratz <bartosz.pankratz@gmail.com>", "Anna Szczurek <annaszczurek2@gmail.com>", "Bogumil Kaminski <bogumil.kaminski@gmail.com>", "Pawel Pralat <pralat@ryerson.ca>"]
-version = "0.1.13"
+version = "0.2.0"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
@@ -17,7 +17,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 DataStructures = "^0.17.0"
 HTTP = "^0.8.0"
-JSON = "^0.21.0"
+JSON = "^0.20.0"
 LibExpat = "^0.6.0"
 LightGraphs = "^1.3.0"
 julia = "^1.3.0"

--- a/src/a_star.jl
+++ b/src/a_star.jl
@@ -1,7 +1,7 @@
 """
     get_distance(A::Int, B::Int, 
                  nodes::Dict{Int,T} , 
-                 vertices_to_nodes::Dict{Int,Int}) where T<:Union{OpenStreetMapX.ENU,OpenStreetMapX.ECEF}
+                 vertices_to_nodes::Vector{Int}) where T<:Union{OpenStreetMapX.ENU,OpenStreetMapX.ECEF}
 					
 Auxiliary function - takes two vertices of graph and return the distance between them. 
 Used to compute straight line distance heuristic for A* algorithm.
@@ -15,7 +15,7 @@ Used to compute straight line distance heuristic for A* algorithm.
 """
 function get_distance(A::Int, B::Int, 
                      nodes::Dict{Int,T}, 
-                     vertices_to_nodes::Dict{Int,Int}) where T<:Union{OpenStreetMapX.ENU,OpenStreetMapX.ECEF}
+                     vertices_to_nodes::Vector{Int}) where T<:Union{OpenStreetMapX.ENU,OpenStreetMapX.ECEF}
     A,B = vertices_to_nodes[A], vertices_to_nodes[B]
     OpenStreetMapX.distance(nodes[A],nodes[B])
 end

--- a/src/routing.jl
+++ b/src/routing.jl
@@ -21,13 +21,6 @@ function get_edges(nodes::Dict{Int,T},roadways::Vector{OpenStreetMapX.Way}) wher
 end
 
 """
-Get Vertices for a set of `edges`
-"""
-function get_vertices(edges::Vector{Tuple{Int,Int}})
-    graph_nodes = unique(reinterpret(Int, edges))
-    vertices = Dict{Int,Int}(zip(graph_nodes, 1:length(graph_nodes)))
-end
-"""
 Get Distances Between Edges
 """
 function distance(nodes::Dict{Int,T},edges::Vector{Tuple{Int,Int}}) where T<:Union{OpenStreetMapX.ENU,OpenStreetMapX.ECEF}

--- a/src/types.jl
+++ b/src/types.jl
@@ -258,7 +258,8 @@ This is the main data structure used fot map data analytics.
 * `roadways` :  unique roads stored as a OpenStreetMapX.Way objects
 * `intersections` : roads intersections
 * `g` : `LightGraphs` directed graph representing a road network
-* `v` : vertices in the road network
+* `v` : vertices in the road network 
+* `n` : OpenStreetMap node ids for the graphs vertices 
 * `e` : edges in the graph represented as a tuple (source,destination)
 * `w` : edge weights, indexed by graph id
 * `class` : road class of each edge
@@ -271,9 +272,9 @@ struct MapData
     # Transporation network graph data and helpers to increase routing speed
     g::LightGraphs.SimpleGraphs.SimpleDiGraph{Int64} # Graph object
     v::Dict{Int,Int}                             # (node id) => (graph vertex)
-	n::Dict{Int,Int}                             # (graph vertex) => (node id)
+	n::Vector{Int}                             # (graph vertex) => (node id)
     e::Vector{Tuple{Int,Int}}                # Edges in graph, stored as a tuple (source,destination)
     w::SparseArrays.SparseMatrixCSC{Float64, Int}   # Edge weights, indexed by graph id
     class::Vector{Int}                           # Road class of each edge
-	#MapData(bounds, nodes, roadways, intersections) = new(bounds, nodes, roadways, intersections, LightGraphs.SimpleGraphs.SimpleDiGraph{Int64}(), Dict{Int,Int}(), Tuple{Int64,Int64}[],  SparseMatrixCSC(Matrix{Float64}(undef,0,0)),Int[])
+	#MapData(bounds, nodes, roadways, intersections) = new(bounds, nodes, roadways, intersections, LightGraphs.SimpleGraphs.SimpleDiGraph{Int64}(), Dict{Int,Int}(),Int[], Tuple{Int64,Int64}[],  SparseMatrixCSC(Matrix{Float64}(undef,0,0)),Int[])
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,8 +61,8 @@ m =  OpenStreetMapX.get_map_data(pth,use_cache = false);
 	#routing.jl/get_edges
 	@test OpenStreetMapX.get_edges(m.nodes,m.roadways[1:2]) == (Tuple{Int64,Int64}[(139988738, 385046327), (2441017870, 2975020216), (385046327, 385046328), (2441017888, 2441017878), (2441017878, 2441017870)], [1, 4, 1, 4, 4])
 
-	#routing.jl/get_vertices
-	@test OpenStreetMapX.get_vertices(OpenStreetMapX.get_edges(m.nodes,m.roadways[1:2])[1]) == Dict(2441017878=>7,139988738=>1,2975020216=>4,2441017870=>3,385046328=>5,2441017888=>6,385046327=>2)
+	#parseMap.jl/get_vertices_and_graph_nodes
+	@test OpenStreetMapX.get_vertices_and_graph_nodes(OpenStreetMapX.get_edges(m.nodes,m.roadways[1:2])[1])[1] == Dict(2441017878=>7,139988738=>1,2975020216=>4,2441017870=>3,385046328=>5,2441017888=>6,385046327=>2)
 
 	#routing.jl/distance
 	#Returns seem to be equal yet returning false (?)


### PR DESCRIPTION
- correct bug in issue 32
- fill the missing docs for `n` field in `MapData` object
- change the type of `n` from a `Dict` having keys `1:LightGraphs.nv(g)`   to a `Vector` for performance reasons 