### PR TITLE
Use n field instead of reconstructing it

### DIFF
--- a/src/routing.jl
+++ b/src/routing.jl
@@ -116,13 +116,8 @@ end
 """
 Extract nodes ID's from route object
 """
-function get_route_nodes(m::MapData, route_indices::Array{Int64,1})
-    route_nodes = Array{Int}(undef,length(route_indices))
-    v = Dict{Int,Int}(reverse.(collect(m.v)))
-    for n = 1:length(route_nodes)
-        route_nodes[n] = v[route_indices[n]]
-    end
-    return route_nodes
+function get_route_nodes(m::MapData, route_indices::Vector{Int})
+    return getindex.(Ref(m.n), route_indices)
 end
 
 """

--- a/src/routing.jl
+++ b/src/routing.jl
@@ -116,7 +116,7 @@ end
 """
 Extract nodes ID's from route object
 """
-function get_route_nodes(m::MapData, route_indices::Vector{Int})
+function get_route_nodes(m::MapData, route_indices::AbstractVector{Int})
     return getindex.(Ref(m.n), route_indices)
 end
 


### PR DESCRIPTION
The `route_nodes` dictionary that is constructed seems to be exactly `m.n`.