### PR TITLE
Fix nodes_within_range

### DIFF
--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -88,7 +88,7 @@ Find nodes within range of a location using a subset of nodes
 """
 function nodes_within_range(nodes::Dict{Int,T}, loc::T, node_list::AbstractSet{Int}, range::Float64 = Inf) where T<:(Union{OpenStreetMapX.ENU,OpenStreetMapX.ECEF})
     if range == Inf
-        return node_list
+        return collect(node_list)
     end
     indices = Int[]
     for ind in node_list
@@ -103,7 +103,7 @@ end
 """
 Find vertices of a routing network within range of a location
 """
-nodes_within_range(nodes::Dict{Int,T},loc::T, m::OpenStreetMapX.MapData, range::Float64 = Inf) where T <:(Union{OpenStreetMapX.ENU,OpenStreetMapX.ECEF}) = OpenStreetMapX.nodes_within_range(nodes,loc,collect(keys(m.v)),range)
+nodes_within_range(nodes::Dict{Int,T},loc::T, m::OpenStreetMapX.MapData, range::Float64 = Inf) where T <:(Union{OpenStreetMapX.ENU,OpenStreetMapX.ECEF}) = OpenStreetMapX.nodes_within_range(nodes,loc,keys(m.v),range)
 
 """
 Compute Centroid of List of Nodes

--- a/src/routing.jl
+++ b/src/routing.jl
@@ -359,7 +359,7 @@ function nodes_within_weights(m::MapData, weights::SparseArrays.SparseMatrixCSC{
     return OpenStreetMapX.filter_vertices(m.v, bellman_ford.dists, limit)
 end
 
-nodes_within_weights(nodes::Dict{Int,T}, m::MapData, weights::SparseArrays.SparseMatrixCSC{Float64,Int64}, loc::T, limit::Float64=Inf,locrange::Float64=500.0) where T<:(Union{OpenStreetMapX.ENU,OpenStreetMapX.ECEF}) = OpenStreetMapX.nodes_within_weights(m, weights, nodes_within_range(nodes, loc, network, locrange), limit)
+nodes_within_weights(nodes::Dict{Int,T}, m::MapData, weights::SparseArrays.SparseMatrixCSC{Float64,Int64}, loc::T, limit::Float64=Inf,locrange::Float64=500.0) where T<:(Union{OpenStreetMapX.ENU,OpenStreetMapX.ECEF}) = OpenStreetMapX.nodes_within_weights(m, weights, nodes_within_range(nodes, loc, m, locrange), limit)
 
 ##############################################################################
 ### Extract Nodes from bellman_fordStates Object Within an (Optional) Limit ###
@@ -372,7 +372,7 @@ function nodes_within_driving_distance(m::MapData, start_indices::Vector{Int}, l
     return OpenStreetMapX.filter_vertices(m.v, bellman_ford.dists, limit)
 end
 
-nodes_within_driving_distance(nodes::Dict{Int,T}, m::MapData, loc::T, limit::Float64=Inf,locrange::Float64=500.0) where T<:(Union{OpenStreetMapX.ENU,OpenStreetMapX.ECEF})= OpenStreetMapX.nodes_within_driving_distance(m, nodes_within_range(nodes, loc ,network, locrange), limit)
+nodes_within_driving_distance(nodes::Dict{Int,T}, m::MapData, loc::T, limit::Float64=Inf,locrange::Float64=500.0) where T<:(Union{OpenStreetMapX.ENU,OpenStreetMapX.ECEF})= OpenStreetMapX.nodes_within_driving_distance(m, nodes_within_range(nodes, loc, m, locrange), limit)
 
 ##############################################################################
 ### Extract Nodes from bellman_fordStates Object Within an (Optional) Limit ###


### PR DESCRIPTION
Fixes a few issues:
* `network` is not defined
* `collect` gives you a `Vector{Int}` which has two issues:
  - It is not a subtype of `AbstractSet{Int}`, we could change the signature
  - Since we just want to iterate once over it, it's a waste to collect
* If `node_list` is an `AbstractSet`, we should collect in case `range` is `Inf` since in the other case, it returns a vector