### PR TITLE
Avoid constructing a Set by using haskey

### DIFF
--- a/src/intersections.jl
+++ b/src/intersections.jl
@@ -64,11 +64,10 @@ Find Segments of Highways ###
 """
 function find_segments(nodes::Dict{Int,T}, highways::Vector{OpenStreetMapX.Way}, intersections::Dict{Int,Set{Int}}) where T<:Union{OpenStreetMapX.ENU,OpenStreetMapX.ECEF}
     segments = OpenStreetMapX.Segment[]
-    intersect = Set(keys(intersections))
     for highway in highways
         firstNode = 1
         for j = 2:length(highway.nodes)
-            if highway.nodes[firstNode] != highway.nodes[j] && (in(highway.nodes[j], intersect)|| j == length(highway.nodes))
+            if highway.nodes[firstNode] != highway.nodes[j] && (haskey(intersections, highway.nodes[j])|| j == length(highway.nodes))
                 if !reverseway(highway)
                     seg = OpenStreetMapX.Segment(highway.nodes[firstNode],highway.nodes[j],highway.nodes[firstNode:j], OpenStreetMapX.distance(nodes, highway.nodes[firstNode:j]), highway.id)
                     push!(segments,seg)


### PR DESCRIPTION
The current approach seems to construct a `Set` so that it's fast to check whether an element is a key of the dictionary.
This seems useless because:
* `haskey(a, b)` is the same as `b in keys(a)`
* In Julia a `c::Set{T}` is a `a::Dict{T,Nothing}` in which case `b in c` is simply `b in keys(a)`

So this is building a second dictionary with exactly the same keys to do `haskey`. Clearly it's best not to do that.