### PR TITLE
Avoid vcat-splatting

### DIFF
--- a/src/google_routing.jl
+++ b/src/google_routing.jl
@@ -98,15 +98,15 @@ Extract route from Google API results
 
 """
 function extract_google_route(routes::Dict)
-    res = Array{Tuple{Float64,Float64},1}[]
+    res = Tuple{Float64,Float64}[]
     legs = routes["legs"]
     for leg in legs
         steps = leg["steps"]
         for step in steps
-            push!(res,OpenStreetMapX.decode(step["polyline"]["points"]))
+            append!(res, OpenStreetMapX.decode(step["polyline"]["points"]))
         end
     end
-    return vcat(res...)
+    return res
 end
 
 """


### PR DESCRIPTION
As I detailed in https://stackoverflow.com/a/68808887/1189815, using `vcat(res...)` is quite problematic. If `res` has a large length, this can even give a StackOverflow.