### PR TITLE
Don't store dist as key in frontier

### DIFF
--- a/src/a_star.jl
+++ b/src/a_star.jl
@@ -59,14 +59,15 @@ function a_star_algorithm(g::LightGraphs.AbstractGraph{U},  # the g
                           heuristic::Function = (u,v) -> zero(T)) where {T, U}
     nvg = nv(g)
     checkbounds(distmx, Base.OneTo(nvg), Base.OneTo(nvg))
-    frontier = DataStructures.PriorityQueue{Tuple{T, U},T}()
-    frontier[(zero(T), U(s))] = zero(T)
+    frontier = DataStructures.PriorityQueue{U,T}()
+    frontier[U(s)] = zero(T)
     dists = fill(typemax(T), nvg)
     parents = zeros(U, nvg)
     colormap = zeros(UInt8, nvg)
     colormap[s] = 1
     @inbounds while !isempty(frontier)
-        (cost_so_far, u) = dequeue!(frontier)
+        u = dequeue!(frontier)
+        cost_so_far = dists[u]
         u == t && (return OpenStreetMapX.extract_a_star_route(parents,s,u), cost_so_far)
         for v in LightGraphs.outneighbors(g, u)
             col = colormap[v]
@@ -77,13 +78,11 @@ function a_star_algorithm(g::LightGraphs.AbstractGraph{U},  # the g
                 if iszero(col)
                     parents[v] = u
                     dists[v] = path_cost
-                    enqueue!(frontier,
-                            (path_cost, v),
-                            path_cost + heuristic(v,t))
+                    enqueue!(frontier, v, path_cost + heuristic(v,t))
                 elseif path_cost < dists[v]
                     parents[v] = u
                     dists[v] = path_cost
-                    frontier[path_cost, v] = path_cost + heuristic(v,t)
+                    frontier[v] = path_cost + heuristic(v,t)
                 end
             end
         end

--- a/src/a_star.jl
+++ b/src/a_star.jl
@@ -60,8 +60,11 @@ function a_star_algorithm(g::LightGraphs.AbstractGraph{U},  # the g
     nvg = nv(g)
     checkbounds(distmx, Base.OneTo(nvg), Base.OneTo(nvg))
     frontier = DataStructures.PriorityQueue{U,T}()
+    # The value should be `heuristic(s, t)` but it does not matter since it will
+    # be `dequeue!`d in the first iteration independently of the value.
     frontier[U(s)] = zero(T)
     dists = fill(typemax(T), nvg)
+    dists[s] = zero(T)
     parents = zeros(U, nvg)
     colormap = zeros(UInt8, nvg)
     colormap[s] = 1


### PR DESCRIPTION
In A*/Dijkstra, there is two approaches for the datastructure:
1) Use a heap, it's very cheap but you can't update the value of a node so you will store the node several times with different distances and once the first one comes out of the heap, you know you can just ignore the rest. Each operation is super cheap as it's just implemented as a `Vector`
2) Use a full-fledged priority queue where you can update values so you never store more elements as the number of nodes you have, but each operation is more costly.

Here, a full-fledged priority queue is used but the distance is stored as well so the same nodes will occupy several slots in the priority queue! In fact, we never check when a node is taken out of the priority queue that the color of this not is not already 2 so we may treat the same node several time!

This PR fixes the issue by not storing the distance in the key, it's in `dists` anyway.