### PR TITLE
Speed up OSMData -> MapData

### DIFF
--- a/src/classification.jl
+++ b/src/classification.jl
@@ -25,9 +25,18 @@ filter_highways(ways::Vector{OpenStreetMapX.Way}) = [way for way in ways if Open
 ### Filter and Classify Highways for Cars ###
 ##############################################
 
+function valid_roadway(way, levels::Set{Int}, classes::Dict{String, Int} = OpenStreetMapX.ROAD_CLASSES)
+    highway = get(way.tags, "highway", "")
+    if isempty(highway) || highway == "services" || !haskey(classes, highway)
+        return false
+    end
+    return OpenStreetMapX.visible(way) && classes[highway] in levels
+end
+
 filter_roadways(ways::Vector{OpenStreetMapX.Way}, classes::Dict{String, Int} = OpenStreetMapX.ROAD_CLASSES; levels::Set{Int} = Set(1:length(OpenStreetMapX.ROAD_CLASSES))) = [way for way in ways if way.tags["highway"] in keys(classes) && classes[way.tags["highway"]] in levels]
 
-classify_roadways(ways::Vector{OpenStreetMapX.Way}, classes::Dict{String, Int} = OpenStreetMapX.ROAD_CLASSES) = Dict{Int,Int}(way.id => classes[way.tags["highway"]] for  way in ways if haskey(classes, way.tags["highway"]))
+classify_roadway(way::Way, classes::Dict{String, Int} = OpenStreetMapX.ROAD_CLASSES) = classes[way.tags["highway"]]
+classify_roadways(ways::Vector{OpenStreetMapX.Way}, classes::Dict{String, Int} = OpenStreetMapX.ROAD_CLASSES) = Dict{Int,Int}(way.id => classify_roadway(way, classes) for way in ways if haskey(classes, way.tags["highway"]))
 
 ####################################################
 ### Filter and Classify Highways for Pedestrians ###


### PR DESCRIPTION
Adding a `@time` at this line:
https://github.com/pszufe/OpenStreetMapX.jl/blob/7a06505eac473fcba360687101676837a3537f46/src/parseMap.jl#L102
Before this PR, I get:
```julia
julia> get_map_data("/home/blegat/Downloads/andorra-latest.osm", use_cache=false);
  0.097901 seconds (222.99 k allocations: 50.380 MiB)

julia> get_map_data("/home/blegat/Downloads/andorra-latest.osm", use_cache=false);
  0.086140 seconds (222.99 k allocations: 50.380 MiB)

julia> get_map_data("/home/blegat/Downloads/andorra-latest.osm", use_cache=false);
  0.150200 seconds (222.99 k allocations: 50.380 MiB, 40.81% gc time)

julia> get_map_data("/home/blegat/Downloads/andorra-latest.osm", use_cache=false);
  0.090045 seconds (222.99 k allocations: 50.380 MiB)
```
After this PR, I get
```julia
julia> get_map_data("/home/blegat/Downloads/andorra-latest.osm", use_cache=false);
  0.026511 seconds (29.02 k allocations: 8.461 MiB)

julia> get_map_data("/home/blegat/Downloads/andorra-latest.osm", use_cache=false);
  0.027412 seconds (29.02 k allocations: 8.461 MiB)

julia> get_map_data("/home/blegat/Downloads/andorra-latest.osm", use_cache=false);
  0.027245 seconds (29.02 k allocations: 8.461 MiB)
```