### PR TITLE
Pin ProtoBuf to v0.11.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ JSON = "^0.20.0, ^0.21.0"
 LibExpat = "^0.6.0"
 LightGraphs = "^1.3.3"
 CodecZlib = "^0.7.0"
-ProtoBuf = "^0.11.0"
+ProtoBuf = "=0.11.3"
 StableRNGs = "^1.0.0"
 julia = "^1.3.0"
 


### PR DESCRIPTION
The reader does not work with ProtoBuf v0.11.4, see https://github.com/JuliaIO/ProtoBuf.jl/issues/191