### PR TITLE
Bump ProtoBuf to v0.11.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ HTTP = "^0.7.0, ^0.8.0, ^0.9.0"
 JSON = "^0.20.0, ^0.21.0"
 LibExpat = "^0.6.1"
 Graphs = "^1.4.1"
-ProtoBuf = "=0.11.3"
+ProtoBuf = "0.11.5"
 StableRNGs = "^1.0.0"
 julia = "^1.3.0"
 


### PR DESCRIPTION
The issue mentioned in https://github.com/pszufe/OpenStreetMapX.jl/pull/58 was fixed in https://github.com/JuliaIO/ProtoBuf.jl/pull/193 so no need to pin anymore