### PR TITLE
[PBF] Fix conversion from enum to its name

### DIFF
--- a/src/pbf.jl
+++ b/src/pbf.jl
@@ -107,7 +107,7 @@ function process_element(osm, pbf_relation::OSMPBF.Relation, table, lat_offset, 
     types = pbf_relation.types
     for i in eachindex(types)
         push!(relation.members, Dict(
-            "type" => OSMPBF.var"Relation.MemberType"[types[i] + 1],
+            "type" => string(types[i]),
             "ref" => string(memids[i]),
         ))
     end


### PR DESCRIPTION
I can now load andorra.osm.pbf without errors from geofabrik